### PR TITLE
resize-none added

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -132,7 +132,7 @@ export default function Contact() {
               value={formData.message}
               onChange={handleChange}
               rows={4}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-black"
+              className="w-full px-3 py-2 border border-gray-300 resize-none rounded-md focus:outline-none focus:ring-1 focus:ring-black"
               required
             ></textarea>
           </div>


### PR DESCRIPTION
**Resize-none added with tailwind to the text area**:

`className: resize-none`

Now it looks as in the picture:
 
![textarea](https://github.com/user-attachments/assets/f6caf698-ed06-472f-89ea-739affd88913)

